### PR TITLE
move jest-coverage-badges to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "Pablo Gonzalez",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^27.5.1"
+    "jest": "^27.5.1",
+     "jest-coverage-badges": "^1.0.0"
   },
   "jest": {
     "coverageReporters": [
@@ -20,8 +21,5 @@
       "text",
       "lcov"
     ]
-  },
-  "dependencies": {
-    "jest-coverage-badges": "^1.0.0"
   }
 }


### PR DESCRIPTION
This will  help in removing npm audit alerts caused by jest-coverage-badges, until https://github.com/pamepeixinho/jest-coverage-badges/issues/19 this is resolved. It is better to remove the dependency on this lib